### PR TITLE
Update Dependencies via Dependable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,20 +1,20 @@
-source "https://rubygems.org/"
+source 'https://rubygems.org/'
 
-gem 'sinatra', '1.4.5'
-gem 'tilt', '1.4.1'
-gem 'rack', '1.5.2'
-gem 'rack-protection', '1.5.0'
-gem 'math24', '~>2.0.0'
-gem 'require_all', '~>1.4.0'
-gem 'thin', '~>1.7.0'
+gem 'sinatra', '~> 1.4.5'
+gem 'tilt', '~> 1.4.1'
+gem 'rack', '~> 1.5.2'
+gem 'rack-protection', '~> 1.5.0'
+gem 'math24', '~> 2.0.1'
+gem 'require_all', '~> 1.4.0'
+gem 'thin', '~> 1.7.0'
 
 group :development, :test do
-  gem 'rspec', '3.0.0'
-  gem 'rspec-core', '3.0.1'
+  gem 'rspec', '~> 3.0.0'
+  gem 'rspec-core', '~> 3.0.1'
   gem 'rack-test'
   gem 'byebug'
 end
 
 group :production do
-  gem 'newrelic_rpm', '~>3.17.1'
+  gem 'newrelic_rpm', '~> 3.17.2.327'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,11 +4,11 @@ GEM
     byebug (9.0.6)
     daemons (1.2.4)
     diff-lcs (1.3)
-    eventmachine (1.2.1)
+    eventmachine (1.2.2)
     math24 (2.0.1)
     newrelic_rpm (3.17.2.327)
-    rack (1.5.2)
-    rack-protection (1.5.0)
+    rack (1.5.5)
+    rack-protection (1.5.3)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -17,7 +17,7 @@ GEM
       rspec-core (~> 3.0.0)
       rspec-expectations (~> 3.0.0)
       rspec-mocks (~> 3.0.0)
-    rspec-core (3.0.1)
+    rspec-core (3.0.4)
       rspec-support (~> 3.0.0)
     rspec-expectations (3.0.4)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -25,10 +25,10 @@ GEM
     rspec-mocks (3.0.4)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.4)
-    sinatra (1.4.5)
-      rack (~> 1.4)
+    sinatra (1.4.8)
+      rack (~> 1.5)
       rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
+      tilt (>= 1.3, < 3)
     thin (1.7.0)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -40,14 +40,17 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
-  math24 (~> 2.0.0)
-  newrelic_rpm (~> 3.17.1)
-  rack (= 1.5.2)
-  rack-protection (= 1.5.0)
+  math24 (~> 2.0.1)
+  newrelic_rpm (~> 3.17.2.327)
+  rack (~> 1.5.2)
+  rack-protection (~> 1.5.0)
   rack-test
   require_all (~> 1.4.0)
-  rspec (= 3.0.0)
-  rspec-core (= 3.0.1)
-  sinatra (= 1.4.5)
+  rspec (~> 3.0.0)
+  rspec-core (~> 3.0.1)
+  sinatra (~> 1.4.5)
   thin (~> 1.7.0)
-  tilt (= 1.4.1)
+  tilt (~> 1.4.1)
+
+BUNDLED WITH
+   1.14.4


### PR DESCRIPTION
Implements the following updates:

Ruby dependency updates



gem: rack
old_version: 1.5.2
new_version: 1.5.5
source: https://github.com/rack/rack
diff: [http://github.com/rack/rack/compare/1.5.2...1.5.5](http://github.com/rack/rack/compare/1.5.2...1.5.5)

gem: rack-protection
old_version: 1.5.0
new_version: 1.5.3

gem: rspec-core
old_version: 3.0.1
new_version: 3.0.4
source: https://github.com/rspec/rspec-core

gem: sinatra
old_version: 1.4.5
new_version: 1.4.8
source: https://github.com/sinatra/sinatra
diff: [http://github.com/sinatra/sinatra/compare/v1.4.5...v1.4.8](http://github.com/sinatra/sinatra/compare/v1.4.5...v1.4.8)

Ruby sub-dependency updates

gem: eventmachine
old_version: 1.2.1
new_version: 1.2.2
source: https://github.com/eventmachine/eventmachine
diff: [https://github.com/eventmachine/eventmachine/compare/v1.2.1...v1.2.2](https://github.com/eventmachine/eventmachine/compare/v1.2.1...v1.2.2)
