### PR TITLE
Update Dependencies via Dependable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,20 +1,20 @@
 source "https://rubygems.org/"
 
-gem 'sinatra', '1.4.5'
-gem 'tilt', '1.4.1'
-gem 'rack', '1.5.2'
-gem 'rack-protection', '1.5.0'
-gem 'math24', '~>2.0.0'
-gem 'require_all', '~>1.4.0'
-gem 'thin', '~>1.7.0'
+gem 'sinatra', '~> 1.4.5'
+gem 'tilt', '~> 1.4.1'
+gem 'rack', '~> 1.5.2'
+gem 'rack-protection', '~> 1.5.0'
+gem 'math24', '~> 2.0.1'
+gem 'require_all', '~> 1.4.0'
+gem 'thin', '~> 1.7.0'
 
 group :development, :test do
-  gem 'rspec', '3.0.0'
-  gem 'rspec-core', '3.0.1'
+  gem 'rspec', '~> 3.0.0'
+  gem 'rspec-core', '~> 3.0.1'
   gem 'rack-test'
   gem 'byebug'
 end
 
 group :production do
-  gem 'newrelic_rpm', '~>3.17.1'
+  gem 'newrelic_rpm', '~> 3.17.2.327'
 end


### PR DESCRIPTION
Update Dependencies via Dependable

## Dependency updates

| Gem | Previous Version | New Version | Source | Diff |
| --- | --- | --- | --- | --- |
| rspec-core | 3.5.4 | 3.6.0 | [rspec/rspec-core](https://github.com/rspec/rspec-core) | [view](http://github.com/rspec/rspec-core/compare/v3.5.4...v3.6.0) |
| rspec | 3.5.0 | 3.6.0 | [rspec/rspec](https://github.com/rspec/rspec) | [view](http://github.com/rspec/rspec/compare/v3.5.0...v3.6.0) |

## Sub-dependency updates

| Gem | Previous Version | New Version | Source | Diff |
| --- | --- | --- | --- | --- |
| rspec-support | 3.5.0 | 3.6.0 | Not Available | Not Available |
| diff-lcs | 1.2.5 | 1.3 | [halostatue/diff-lcs/](https://github.com/halostatue/diff-lcs/) | Not Available |
| unf_ext | 0.0.7.2 | 0.0.7.4 | Not Available | Not Available |
| rspec-expectations | 3.5.0 | 3.6.0 | [rspec/rspec-expectations](https://github.com/rspec/rspec-expectations) | [view](http://github.com/rspec/rspec-expectations/compare/v3.5.0...v3.6.0) |
| rspec-mocks | 3.5.0 | 3.6.0 | [rspec/rspec-mocks](https://github.com/rspec/rspec-mocks) | [view](http://github.com/rspec/rspec-mocks/compare/v3.5.0...v3.6.0) |
| addressable | 2.3.8 | 2.5.1 | [sporkmonger/addressable](https://github.com/sporkmonger/addressable) | [view](http://github.com/sporkmonger/addressable/compare/addressable-2.3.8...addressable-2.5.1) |
| faraday | 0.10.0 | 0.13.0 | Not Available | Not Available |
| domain_name | 0.5.20161129 | 0.5.20170404 | [knu/ruby-domain_name](https://github.com/knu/ruby-domain_name) | [view](https://github.com/knu/ruby-domain_name/compare/v0.5.20161129...v0.5.20170404) |
| keen | 0.9.6 | 1.1.1 | Not Available | Not Available |
| octokit | 4.6.2 | 4.7.0 | Not Available | Not Available |
| rest-client | 2.0.0 | 2.0.2 | [rest-client/rest-client](https://github.com/rest-client/rest-client) | [view](https://github.com/rest-client/rest-client/compare/v2.0.0...v2.0.2) |